### PR TITLE
Added the core SHA value to the app's version name.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,12 +28,13 @@ android {
 
     val gitTagCount = "git tag --list".runCommand().split('\n').size
     val gitTag = "git describe --tags --dirty".runCommand()
+    val gitCoreSha = "git submodule status".runCommand().substring(0, 8)
 
     defaultConfig {
         applicationId = "org.tiqr.authenticator"
         //add 22 to versioncode, to match previous manual releases
         versionCode = gitTagCount.toInt() + 22
-        versionName = gitTag.toString().trim().drop(1)
+        versionName = gitTag.trim().drop(1) + " core($gitCoreSha)"
 
         logger.lifecycle("Building version " + versionName + "(" + versionCode + ")", "info")
 


### PR DESCRIPTION
### Pull Request Checklist
- [x] I have added proper commit messages
- [ ] I have updated tests and documentation
- [x] I ran the tests
- [x] I provided the ticket number as PR title
- [ ] I have assigned the required reviewers

### Short Description of Change

Added the core SHA value to the app's version name.

### Motivation and Context

Currently the app-core submodule dependency is not using any tagging mechanism and since gradle no longer supports version codes for android libraries, the next best thing is to use the commit SHA of the git submodule. 

### Testing Steps

Open the About screen

### Additional Information
<img width="464" alt="Screenshot 2022-11-17 at 12 25 01" src="https://user-images.githubusercontent.com/2356050/202434385-872b6381-1e19-40aa-b19e-4fedeae0b8db.png">
