### PR TITLE
Add kanazawa-u.ac.jp to the list of allowed domains

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,7 @@ android {
         manifestPlaceholders["tiqr_config_protocol_version"] = "2"
         manifestPlaceholders["tiqr_config_protocol_compatibility_mode"] = "true"
         manifestPlaceholders["tiqr_config_enforce_challenge_hosts"] =
-            "tiqr.nl,tiqr.org,surfconext.nl"
+            "tiqr.nl,tiqr.org,surfconext.nl,kanazawa-u.ac.jp"
         manifestPlaceholders["tiqr_config_enroll_path_param"] = "tiqrenroll"
         manifestPlaceholders["tiqr_config_auth_path_param"] = "tiqrauth"
         manifestPlaceholders["tiqr_config_enroll_scheme"] = "tiqrenroll"


### PR DESCRIPTION
Solves #43

### Pull Request Checklist
- [x] I have added proper commit messages
- [ ] I have updated tests and documentation
- [ ] I ran the tests
- [ ] I provided the ticket number as PR title
- [x] I have assigned the required reviewers

### Short Description of Change
<!-- Please provide information regarding the change -->
```
Add the base domain for the Japanese university Kanazawa to allow tiqr authentication and enrollment
```
