### PR TITLE
Disable Tiqr server host whitelist #43

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,7 @@ android {
         manifestPlaceholders["tiqr_config_protocol_version"] = "2"
         manifestPlaceholders["tiqr_config_protocol_compatibility_mode"] = "true"
         manifestPlaceholders["tiqr_config_enforce_challenge_hosts"] =
-            "tiqr.nl,tiqr.org,surfconext.nl,kanazawa-u.ac.jp,sante-na.fr"
+            ""
         manifestPlaceholders["tiqr_config_enroll_path_param"] = "tiqrenroll"
         manifestPlaceholders["tiqr_config_auth_path_param"] = "tiqrauth"
         manifestPlaceholders["tiqr_config_enroll_scheme"] = "tiqrenroll"


### PR DESCRIPTION
Disable the whitelist of domains of allowed Tiqr servers.

This feature was implemented for the eduID app where the Tiqr servers are known, for the Tiqr app this is not true.