### PR TITLE
TIQR-340: Allow all domain names to use Tiqr

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,8 +48,7 @@ android {
         manifestPlaceholders["tiqr_config_token_exchange_base_url"] = "https://tx.tiqr.org/"
         manifestPlaceholders["tiqr_config_protocol_version"] = "2"
         manifestPlaceholders["tiqr_config_protocol_compatibility_mode"] = "true"
-        manifestPlaceholders["tiqr_config_enforce_challenge_hosts"] =
-            "tiqr.nl,tiqr.org,surfconext.nl,kanazawa-u.ac.jp,sante-na.fr"
+        manifestPlaceholders["tiqr_config_enforce_challenge_hosts"] = ""
         manifestPlaceholders["tiqr_config_enroll_path_param"] = "tiqrenroll"
         manifestPlaceholders["tiqr_config_auth_path_param"] = "tiqrauth"
         manifestPlaceholders["tiqr_config_enroll_scheme"] = "tiqrenroll"


### PR DESCRIPTION
### Pull Request Checklist
- [x] I have added proper commit messages
- [ ] I have updated tests and documentation
- [ ] I ran the tests
- [x] I provided the ticket number as PR title
- [x] I have assigned the required reviewers

### Short Description of Change
<!-- Please provide information regarding the change -->
```
The current tiqr apps have an option to configure a list of allowed domein names in the url’s/qr-codes.


Since Tiqr is used by many organisations, this is not useful. For the eduID app it is.

Add en option do enable/disable the enforcement of the domain names, so we can disable it for the tiqr-app, but still use it for the eduID app.
```
